### PR TITLE
Fix lint errors: remove unused WebSocket parameters

### DIFF
--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -30,14 +30,14 @@ const server = Bun.serve({
     },
   },
   websocket: {
-    open: (ws) => {
+    open: () => {
       console.log("WebSocket connection opened");
     },
-    message: (ws, message) => {
+    message: (_, message) => {
       // Forward WebSocket messages to backend
       console.log("WebSocket message:", message);
     },
-    close: (ws) => {
+    close: () => {
       console.log("WebSocket connection closed");
     },
   },
@@ -48,4 +48,4 @@ const server = Bun.serve({
 });
 
 console.log(`🚀 Frontend server running at http://localhost:${server.port}`);
-console.log(`📝 Environment: ${process.env.NODE_ENV || 'development'}`); 
+console.log(`📝 Environment: ${process.env.NODE_ENV || 'development'}`);    


### PR DESCRIPTION
# Fix lint errors: remove unused WebSocket parameters

## Summary
This PR fixes ESLint `@typescript-eslint/no-unused-vars` errors by removing unused WebSocket parameters from the WebSocket handlers in `frontend/index.ts`. The WebSocket handlers for `open`, `message`, and `close` events were receiving a `ws` parameter that was never used in the function bodies.

The changes:
- Remove unused `ws` parameter from `open` and `close` handlers 
- Keep only the `message` parameter in the `message` handler since it's actually used
- All handlers continue to function the same way, just without unused parameters

## Review & Testing Checklist for Human
- [ ] Test that WebSocket connections can be established successfully (most critical)
- [ ] Verify WebSocket message handling still works correctly 
- [ ] Confirm lint now passes without errors (`bun run lint`)

**Recommended test plan**: Start both frontend and backend servers, open browser dev tools, and verify WebSocket connection is established and messages can be sent/received properly.

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    FE["frontend/index.ts<br/>Main Bun server"]:::major-edit
    WS["WebSocket handlers<br/>(open, message, close)"]:::major-edit
    BE["Backend API<br/>(localhost:8000)"]:::context
    
    FE --> WS
    FE --> BE
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
This was a simple lint fix requested as part of testing repo access and PR creation workflow. The changes are minimal but WebSocket functionality should be verified since it's core to the platform's operation.

Link to Devin run: https://app.devin.ai/sessions/309e9e6c353c42f588ef4eae378a3de1
Requested by: Daniel Zhou (@danielhzhou)