### PR TITLE
Fix DNS resolution failure for pip/npm package installation

### DIFF
--- a/backend/app/services/container_service.py
+++ b/backend/app/services/container_service.py
@@ -497,8 +497,7 @@ Happy coding! 🐍
                 logger.info(f"Creating PyPI network: {settings.PYPI_NETWORK_NAME}")
                 self.docker.network.create(
                     name=settings.PYPI_NETWORK_NAME,
-                    driver="bridge",
-                    internal=False  # Allow external access
+                    driver="bridge"
                 )
         except DockerException as e:
             logger.error(f"Failed to ensure PyPI network exists: {e}")
@@ -683,4 +682,4 @@ Happy coding! 🐍
 
 
 # Global container service instance
-container_service = ContainerService() 
+container_service = ContainerService()  


### PR DESCRIPTION
# Fix DNS resolution failure for pip/npm package installation

## Summary

Fixed a critical bug preventing package installation in Docker containers. The issue was caused by an invalid `internal=False` parameter being passed to the `docker.network.create()` call in the container service. The python-on-whales library doesn't support this parameter, causing network creation to fail silently and leaving containers without access to external package repositories.

**Root cause**: `NetworkCLI.create() got an unexpected keyword argument 'internal'` error in `_ensure_network_exists()` method  
**Solution**: Removed the unsupported parameter - networks are external by default, which is exactly what we need for package installation  
**Impact**: pip/npm commands now work properly instead of failing with "Temporary failure in name resolution"

## Review & Testing Checklist for Human

- [ ] **Verify PyPI network creation**: Start the backend and confirm `docker network ls` shows the `pypi-net` network is created successfully
- [ ] **Test package installation end-to-end**: Create a container through the platform UI/API and run `pip install beautifulsoup4` to verify it works without DNS errors
- [ ] **Verify network access control**: Confirm that network access is automatically enabled for package commands and disabled afterward for security
- [ ] **Test npm/yarn commands**: Verify that npm/yarn package installation also works correctly with the network configuration

**Recommended test plan**: 
1. Start the backend and verify no network creation errors in logs
2. Create a container and test both pip and npm package installations
3. Verify that non-package commands don't trigger network access
4. Confirm containers are properly isolated when network access is disabled

## Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["backend/app/main.py"]:::context --> B["container_service.start()"]:::context
    B --> C["backend/app/services/<br/>container_service.py<br/>_ensure_network_exists()"]:::major-edit
    C --> D["docker.network.create()"]:::major-edit
    D --> E["pypi-net network"]:::context
    
    F["terminal commands<br/>(pip install, npm install)"]:::context --> G["terminal_service<br/>_needs_network_access()"]:::context
    G --> H["enable_network_access()"]:::context
    H --> I["Connect container to<br/>pypi-net"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

## Notes

- **Change is minimal but critical**: Only removed one invalid parameter, but this was blocking all package installations
- **Security consideration**: The network is external by default (same as before), allowing necessary package repository access while maintaining container isolation
- **Testing limitations**: Database connectivity issues prevented full end-to-end API testing, but manual Docker testing confirmed the fix works
- **Network security**: The platform still properly controls network access - enabling it only during package installation commands and disabling it afterward

**Session info**: 
- Link to Devin run: https://app.devin.ai/sessions/8c54f4c536a74b76865a3136839775c8
- Requested by: DANIEL ZHOU (@danielhzhou)