### PR TITLE
Fix Docker network creation error preventing file creation feature

### DIFF
--- a/backend/app/services/container_service.py
+++ b/backend/app/services/container_service.py
@@ -497,8 +497,7 @@ Happy coding! 🐍
                 logger.info(f"Creating PyPI network: {settings.PYPI_NETWORK_NAME}")
                 self.docker.network.create(
                     name=settings.PYPI_NETWORK_NAME,
-                    driver="bridge",
-                    internal=False  # Allow external access
+                    driver="bridge"
                 )
         except DockerException as e:
             logger.error(f"Failed to ensure PyPI network exists: {e}")
@@ -683,4 +682,4 @@ Happy coding! 🐍
 
 
 # Global container service instance
-container_service = ContainerService() 
+container_service = ContainerService()  


### PR DESCRIPTION
# Fix Docker network creation error preventing file creation feature

## Summary

Fixed a critical Docker network creation error that was preventing the container service from starting, which blocked the entire file creation feature. The issue was an unsupported `internal=False` parameter in the `docker.network.create()` call that caused the error: "NetworkCLI.create() got an unexpected keyword argument 'internal'".

**Key changes:**
- Removed the unsupported `internal=False` parameter from network creation in `container_service.py`
- Container service now starts successfully and creates the required `pypi-net` Docker network
- This unblocks the file creation workflow from Monaco editor to Docker containers

## Review & Testing Checklist for Human

**⚠️ Important:** Due to Supabase database connectivity issues during development, I could only verify the Docker network fix but not the complete end-to-end file creation workflow. Please test thoroughly:

- [ ] **Test complete file creation workflow**: Create account → login → create files through UI → verify files exist in Docker containers
- [ ] **Verify external network access**: Ensure containers can still access PyPI and install packages (the removed `internal=False` parameter was intended to "Allow external access")
- [ ] **Check Docker network properties**: Verify `pypi-net` network behavior is correct without the `internal` parameter
- [ ] **Test file synchronization**: Create/edit files in Monaco editor and confirm changes are saved to container filesystem
- [ ] **Test edge cases**: Try creating nested directories, special characters in filenames, large files

## Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    subgraph "File Creation Flow"
        UI["frontend/src/components/layout/<br/>FileTree.tsx"]
        API["frontend/src/lib/api.ts"]
        Backend["backend/app/api/routes/<br/>containers.py"]
        ContainerService["backend/app/services/<br/>container_service.py"]:::major-edit
        Docker["Docker Network<br/>(pypi-net)"]
    end
    
    UI -->|"createFile()"| API
    API -->|"POST /containers/{id}/files"| Backend  
    Backend -->|"save_container_file()"| ContainerService
    ContainerService -->|"network.create()"| Docker
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Root cause**: The `python-on-whales` library version doesn't support the `internal` parameter in network creation
- **Verification completed**: Docker network creation works, container service starts successfully
- **Testing limitation**: Could not test full file creation workflow due to authentication/database connectivity issues
- **File creation implementation**: Complete end-to-end implementation exists (UI → API → Docker), just needed the Docker network fix

---


**Link to Devin run**: https://app.devin.ai/sessions/29eb6b4db2604225b329ab488dedc99a  
**Requested by**: @danielhzhou